### PR TITLE
Add append log flag to forever so you can stop/start the forever server

### DIFF
--- a/bin/squarespace-server
+++ b/bin/squarespace-server
@@ -37,7 +37,7 @@ if ( versionIdx !== -1 ) {
     // Splice --forever flag from the argument list
     args.splice( foreverIdx, 1 );
 
-    exec( (forever + " --uid 'node-squarespace-server' start " + startup + " " + args.join( " " ) ), function ( error, stdout ) {} );
+    exec( (forever + " -a --uid 'node-squarespace-server' start " + startup + " " + args.join( " " ) ), function ( error, stdout ) {} );
 
 // Stop server started with forever process
 } else if ( forneverIdx !== -1 ) {


### PR DESCRIPTION
Without the append flag (-a), foreverjs would error out, stating that the log file for node-squarespace-server already existed. THis appends the log, allowing the server to start correctly.