### PR TITLE
Add logging of 404 request url.

### DIFF
--- a/squarespace-server.js
+++ b/squarespace-server.js
@@ -217,7 +217,7 @@ renderResponse = function ( appRequest, appResponse ) {
                 if ( data.html.status === 404 || data.json.status === 404 ) {
                     appResponse.status( 200 ).send( fourOhFourHTML );
 
-                    sqsUtil.log( "Server.404" );
+                    sqsUtil.log( "Server.404: " + url );
 
                     return;
                 }


### PR DESCRIPTION
Adds the actual path that resulted in a 404 to the server log message. Small change but I found it useful for tracking down a template logic bug that was causing a bad image name to be output as the server log is cleaner than the browser's network tab.